### PR TITLE
Set up basic Snaphunt project structure

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -1,0 +1,17 @@
+<?php
+// CORS headers
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+// Database connection constants
+define('DB_HOST', 'localhost');
+define('DB_NAME', 'snaphunt');
+define('DB_USER', 'username');
+define('DB_PASS', 'password');
+
+// Upload settings
+define('UPLOAD_DIR', __DIR__ . '/../uploads/');
+define('MAX_FILE_SIZE', 5 * 1024 * 1024); // 5MB
+define('ALLOWED_EXTENSIONS', ['jpg', 'jpeg', 'png']);
+?>

--- a/api/database.php
+++ b/api/database.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+class Database
+{
+    private $pdo;
+
+    public function __construct()
+    {
+        $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ];
+        $this->pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+    }
+
+    public function getConnection()
+    {
+        return $this->pdo;
+    }
+}
+?>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,49 @@
+:root {
+    --primary-color: #0066ff;
+    --secondary-color: #f0f0f0;
+    --text-color: #333;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: var(--secondary-color);
+    color: var(--text-color);
+}
+
+.screen {
+    padding: 1rem;
+}
+
+.hidden {
+    display: none;
+}
+
+button,
+input {
+    padding: 0.5rem;
+    font-size: 1rem;
+    margin: 0.25rem 0;
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+}
+
+button {
+    background: var(--primary-color);
+    color: #fff;
+    cursor: pointer;
+}
+
+#map {
+    height: 400px;
+}
+
+@media (min-width: 600px) {
+    #map {
+        height: 100vh;
+    }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Snaphunt application logic will go here.
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snaphunt</title>
+    <link rel="stylesheet" href="assets/css/main.css" />
+    <link
+        rel="stylesheet"
+        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-o9N1j7SoDw7e9iLFNMGxVg0jjDPzLwE0XNyBlt8mPLo="
+        crossorigin=""
+    />
+</head>
+<body>
+    <div id="loading-screen" class="screen">Loading...</div>
+
+    <div id="join-screen" class="screen hidden">
+        <h1>Join Game</h1>
+        <input type="text" placeholder="Join Code" />
+        <button id="join-button">Join</button>
+    </div>
+
+    <div id="game-screen" class="screen hidden">
+        <div id="map"></div>
+    </div>
+
+    <script
+        src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-QVfgPfnBE3ZM4AeQUwGDi5KknpsosiBwPGG/J4m7MQw="
+        crossorigin=""
+    ></script>
+    <script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,70 @@
+CREATE TABLE games (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    join_code VARCHAR(8) NOT NULL UNIQUE,
+    status ENUM('waiting','active','finished') NOT NULL DEFAULT 'waiting',
+    photo_interval_seconds INT NOT NULL DEFAULT 120,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE teams (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    game_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    role ENUM('hunted','hunter') NOT NULL,
+    join_code VARCHAR(8) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (game_id) REFERENCES games(id)
+);
+
+CREATE TABLE players (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    team_id INT NOT NULL,
+    device_id VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    is_captain BOOLEAN NOT NULL DEFAULT FALSE,
+    last_seen TIMESTAMP NULL,
+    FOREIGN KEY (team_id) REFERENCES teams(id)
+);
+
+CREATE TABLE photo_slots (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    game_id INT NOT NULL,
+    team_id INT NOT NULL,
+    slot_number INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (game_id) REFERENCES games(id),
+    FOREIGN KEY (team_id) REFERENCES teams(id)
+);
+
+CREATE TABLE photos (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    slot_id INT NOT NULL,
+    player_id INT NOT NULL,
+    file_path VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (slot_id) REFERENCES photo_slots(id),
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+CREATE TABLE location_pings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    latitude DECIMAL(10,8) NOT NULL,
+    longitude DECIMAL(11,8) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+CREATE TABLE game_events (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    game_id INT NOT NULL,
+    team_id INT NULL,
+    player_id INT NULL,
+    event_type VARCHAR(50) NOT NULL,
+    event_data TEXT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (game_id) REFERENCES games(id),
+    FOREIGN KEY (team_id) REFERENCES teams(id),
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,0 +1,3 @@
+# Uploaded files
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- Scaffold core web assets and API configuration
- Define database schema for games, teams, players, and related tables
- Add placeholder JavaScript and uploads directory setup

## Testing
- `php -l api/config.php`
- `php -l api/database.php`


------
https://chatgpt.com/codex/tasks/task_e_68a880f908208323bd60d5083481a345