### PR TITLE
Add game creation API and admin interface

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Create Game - Snaphunt</title>
+    <link rel="stylesheet" href="assets/css/main.css" />
+</head>
+<body>
+    <h1>Create Game</h1>
+    <form id="create-game-form">
+        <label for="game-name">Game Name</label>
+        <input type="text" id="game-name" required />
+
+        <label for="photo-interval">Photo Interval (seconds)</label>
+        <input type="range" id="photo-interval" min="60" max="300" value="120" />
+        <span id="interval-display">120</span>
+
+        <button type="submit" id="submit-btn">Create Game</button>
+    </form>
+    <div id="message"></div>
+
+    <div id="result" class="hidden">
+        <h2>Join Code: <span id="join-code"></span></h2>
+        <button id="copy-code">Copy Code</button>
+    </div>
+
+    <p><a href="index.html">Back to main game</a></p>
+
+    <script src="assets/js/admin.js"></script>
+</body>
+</html>

--- a/api/game.php
+++ b/api/game.php
@@ -1,0 +1,127 @@
+<?php
+require_once __DIR__ . '/database.php';
+
+header('Content-Type: application/json');
+
+function send_response(int $status, array $data): void
+{
+    http_response_code($status);
+    echo json_encode($data);
+    exit;
+}
+
+$action = $_GET['action'] ?? '';
+$db = new Database();
+$pdo = $db->getConnection();
+
+function generate_join_code(PDO $pdo): string
+{
+    $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    do {
+        $code = '';
+        for ($i = 0; $i < 6; $i++) {
+            $code .= $chars[random_int(0, strlen($chars) - 1)];
+        }
+        $stmt = $pdo->prepare('SELECT id FROM games WHERE join_code = ?');
+        $stmt->execute([$code]);
+        $exists = $stmt->fetch();
+    } while ($exists);
+    return $code;
+}
+
+try {
+    switch ($action) {
+        case 'create':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                send_response(400, ['error' => 'Invalid request method']);
+            }
+            $input = json_decode(file_get_contents('php://input'), true);
+            $name = trim($input['name'] ?? '');
+            $interval = (int)($input['photo_interval_seconds'] ?? 0);
+            if ($name === '' || $interval < 60 || $interval > 300) {
+                send_response(400, ['error' => 'Invalid input']);
+            }
+            $join_code = generate_join_code($pdo);
+            $stmt = $pdo->prepare('INSERT INTO games (name, join_code, photo_interval_seconds) VALUES (?, ?, ?)');
+            try {
+                $stmt->execute([$name, $join_code, $interval]);
+            } catch (PDOException $e) {
+                send_response(409, ['error' => 'Duplicate join code']);
+            }
+            send_response(200, [
+                'success' => true,
+                'game_id' => $pdo->lastInsertId(),
+                'join_code' => $join_code,
+            ]);
+            break;
+
+        case 'get':
+            $code = $_GET['code'] ?? '';
+            if (!preg_match('/^[A-Z0-9]{6}$/', $code)) {
+                send_response(400, ['error' => 'Invalid join code']);
+            }
+            $stmt = $pdo->prepare('SELECT id, name, status FROM games WHERE join_code = ?');
+            $stmt->execute([$code]);
+            $game = $stmt->fetch();
+            if (!$game) {
+                send_response(404, ['error' => 'Game not found']);
+            }
+            $stmt = $pdo->prepare('SELECT COUNT(*) AS teams FROM teams WHERE game_id = ?');
+            $stmt->execute([$game['id']]);
+            $teams = (int)$stmt->fetch()['teams'];
+            send_response(200, [
+                'success' => true,
+                'name' => $game['name'],
+                'status' => $game['status'],
+                'teams' => $teams,
+            ]);
+            break;
+
+        case 'start':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                send_response(400, ['error' => 'Invalid request method']);
+            }
+            $code = $_GET['code'] ?? '';
+            if (!preg_match('/^[A-Z0-9]{6}$/', $code)) {
+                send_response(400, ['error' => 'Invalid join code']);
+            }
+            $stmt = $pdo->prepare('UPDATE games SET status = "active", started_at = NOW() WHERE join_code = ?');
+            $stmt->execute([$code]);
+            if ($stmt->rowCount() === 0) {
+                send_response(404, ['error' => 'Game not found']);
+            }
+            send_response(200, ['success' => true]);
+            break;
+
+        case 'status':
+            $code = $_GET['code'] ?? '';
+            if (!preg_match('/^[A-Z0-9]{6}$/', $code)) {
+                send_response(400, ['error' => 'Invalid join code']);
+            }
+            $stmt = $pdo->prepare('SELECT id, status FROM games WHERE join_code = ?');
+            $stmt->execute([$code]);
+            $game = $stmt->fetch();
+            if (!$game) {
+                send_response(404, ['error' => 'Game not found']);
+            }
+            $stmt = $pdo->prepare('SELECT COUNT(*) AS teams FROM teams WHERE game_id = ?');
+            $stmt->execute([$game['id']]);
+            $teams = (int)$stmt->fetch()['teams'];
+            $stmt = $pdo->prepare('SELECT COALESCE(MAX(slot_number),0) AS slot FROM photo_slots WHERE game_id = ?');
+            $stmt->execute([$game['id']]);
+            $slot = (int)$stmt->fetch()['slot'];
+            send_response(200, [
+                'success' => true,
+                'status' => $game['status'],
+                'active_teams' => $teams,
+                'current_photo_slot' => $slot,
+            ]);
+            break;
+
+        default:
+            send_response(400, ['error' => 'Invalid action']);
+    }
+} catch (Exception $e) {
+    send_response(500, ['error' => 'Server error']);
+}
+?>

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('create-game-form');
+    const nameInput = document.getElementById('game-name');
+    const intervalInput = document.getElementById('photo-interval');
+    const intervalDisplay = document.getElementById('interval-display');
+    const submitBtn = document.getElementById('submit-btn');
+    const message = document.getElementById('message');
+    const result = document.getElementById('result');
+    const joinCodeSpan = document.getElementById('join-code');
+    const copyBtn = document.getElementById('copy-code');
+
+    intervalInput.addEventListener('input', () => {
+        intervalDisplay.textContent = intervalInput.value;
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        message.textContent = '';
+        const name = nameInput.value.trim();
+        if (!name) {
+            message.textContent = 'Please enter a game name.';
+            return;
+        }
+        submitBtn.disabled = true;
+        submitBtn.textContent = 'Creating...';
+        try {
+            const response = await fetch('api/game.php?action=create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name,
+                    photo_interval_seconds: parseInt(intervalInput.value, 10)
+                })
+            });
+            const data = await response.json();
+            if (response.ok && data.join_code) {
+                joinCodeSpan.textContent = data.join_code;
+                result.classList.remove('hidden');
+                message.textContent = 'Game created!';
+            } else {
+                message.textContent = data.error || 'Error creating game.';
+            }
+        } catch (err) {
+            message.textContent = 'Network error.';
+        } finally {
+            submitBtn.disabled = false;
+            submitBtn.textContent = 'Create Game';
+        }
+    });
+
+    copyBtn.addEventListener('click', async () => {
+        try {
+            await navigator.clipboard.writeText(joinCodeSpan.textContent);
+            message.textContent = 'Join code copied to clipboard.';
+        } catch (err) {
+            message.textContent = 'Unable to copy join code.';
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Implement PHP API endpoints for game creation, retrieval, start, and status
- Add admin interface to create games and display join codes
- Include frontend logic for AJAX calls and join-code clipboard copying

## Testing
- `php -l api/game.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8826a70c883239085fa458937478d