### PR TITLE
fix: show loading screen on initial page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
 <body>
-    <div id="loading-screen" class="screen">Loading...</div>
+    <div id="loading-screen" class="screen active">Loading...</div>
 
     <div id="join-screen" class="screen hidden">
         <h1>Join Game</h1>


### PR DESCRIPTION
## Summary
- add missing `active` class so loading screen is visible on page load

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88bbd4e548323b410e70e7d9d0b56