### PR TITLE
Initialize Snaphunt immediately when DOM is ready

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,16 @@
+console.log('🔥 app.js EXECUTING - before DOMContentLoaded');
 console.log('📜 app.js loaded');
 
-document.addEventListener('DOMContentLoaded', () => {
-    console.log('📦 DOMContentLoaded fired');
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        console.log('📦 DOMContentLoaded fired');
+        initializeSnaphunt();
+    });
+} else {
+    initializeSnaphunt();
+}
+
+function initializeSnaphunt() {
     console.log('🚀 Snaphunt App Starting...');
 
     try {
@@ -196,5 +205,6 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (error) {
         console.error('❌ Fatal error during initialization:', error);
     }
-});
+}
+
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
             onload="console.log('✅ Leaflet script loaded')"
             onerror="console.error('❌ Failed to load Leaflet script', event)"></script>
-    <script src="assets/js/app.js" defer
+    <script src="assets/js/app.js"
             onload="console.log('✅ app.js loaded')"
             onerror="console.error('❌ Failed to load app.js', event)"></script>
 </body>


### PR DESCRIPTION
## Summary
- Ensure app.js runs by checking document.readyState and calling initializeSnaphunt immediately
- Remove defer from app.js script tag so code executes once loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88d84c81083238efc3af3b88ec1e6