### PR TITLE
Add team selection UI and team API endpoints

### DIFF
--- a/api/team.php
+++ b/api/team.php
@@ -1,0 +1,140 @@
+<?php
+require_once __DIR__ . '/database.php';
+
+header('Content-Type: application/json');
+
+function send_response(int $status, array $data): void
+{
+    http_response_code($status);
+    echo json_encode($data);
+    exit;
+}
+
+$action = $_GET['action'] ?? '';
+$db = new Database();
+$pdo = $db->getConnection();
+
+function generate_team_code(PDO $pdo): string
+{
+    $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    do {
+        $code = '';
+        for ($i = 0; $i < 6; $i++) {
+            $code .= $chars[random_int(0, strlen($chars) - 1)];
+        }
+        $stmt = $pdo->prepare('SELECT id FROM teams WHERE join_code = ?');
+        $stmt->execute([$code]);
+        $exists = $stmt->fetch();
+    } while ($exists);
+    return $code;
+}
+
+try {
+    switch ($action) {
+        case 'list':
+            $code = $_GET['game_code'] ?? '';
+            if (!preg_match('/^[A-Z0-9]{6}$/', $code)) {
+                send_response(400, ['error' => 'Invalid game code']);
+            }
+            $stmt = $pdo->prepare('SELECT id FROM games WHERE join_code = ?');
+            $stmt->execute([$code]);
+            $game = $stmt->fetch();
+            if (!$game) {
+                send_response(404, ['error' => 'Game not found']);
+            }
+            $stmt = $pdo->prepare('SELECT t.id, t.name, t.role, t.join_code, (SELECT COUNT(*) FROM players p WHERE p.team_id = t.id) AS player_count FROM teams t WHERE t.game_id = ?');
+            $stmt->execute([$game['id']]);
+            $teams = $stmt->fetchAll();
+            send_response(200, ['success' => true, 'teams' => $teams]);
+            break;
+
+        case 'create':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                send_response(400, ['error' => 'Invalid request method']);
+            }
+            $input = json_decode(file_get_contents('php://input'), true);
+            $game_code = $input['game_code'] ?? '';
+            $team_name = trim($input['team_name'] ?? '');
+            $role = $input['role'] ?? '';
+            $player_name = trim($input['player_name'] ?? '');
+            $device_id = trim($input['device_id'] ?? '');
+            if (!preg_match('/^[A-Z0-9]{6}$/', $game_code) || $team_name === '' || $player_name === '' || !in_array($role, ['hunted', 'hunter'], true) || $device_id === '') {
+                send_response(400, ['error' => 'Invalid input']);
+            }
+            $stmt = $pdo->prepare('SELECT id FROM games WHERE join_code = ?');
+            $stmt->execute([$game_code]);
+            $game = $stmt->fetch();
+            if (!$game) {
+                send_response(404, ['error' => 'Game not found']);
+            }
+            $game_id = $game['id'];
+            $stmt = $pdo->prepare('SELECT p.id FROM players p JOIN teams t ON p.team_id = t.id WHERE t.game_id = ? AND p.device_id = ?');
+            $stmt->execute([$game_id, $device_id]);
+            if ($stmt->fetch()) {
+                send_response(409, ['error' => 'Device already joined a team']);
+            }
+            $stmt = $pdo->prepare('SELECT id FROM teams WHERE game_id = ? AND name = ?');
+            $stmt->execute([$game_id, $team_name]);
+            if ($stmt->fetch()) {
+                send_response(409, ['error' => 'Team name already exists']);
+            }
+            if ($role === 'hunted') {
+                $stmt = $pdo->prepare("SELECT id FROM teams WHERE game_id = ? AND role = 'hunted'");
+                $stmt->execute([$game_id]);
+                if ($stmt->fetch()) {
+                    send_response(409, ['error' => 'Hunted team already exists']);
+                }
+            }
+            $team_code = generate_team_code($pdo);
+            $stmt = $pdo->prepare('INSERT INTO teams (game_id, name, role, join_code) VALUES (?,?,?,?)');
+            $stmt->execute([$game_id, $team_name, $role, $team_code]);
+            $team_id = $pdo->lastInsertId();
+            $stmt = $pdo->prepare('INSERT INTO players (team_id, device_id, display_name, is_captain) VALUES (?,?,?,1)');
+            $stmt->execute([$team_id, $device_id, $player_name]);
+            $player_id = $pdo->lastInsertId();
+            send_response(200, [
+                'success' => true,
+                'team' => ['id' => $team_id, 'name' => $team_name, 'role' => $role, 'join_code' => $team_code],
+                'player' => ['id' => $player_id, 'name' => $player_name]
+            ]);
+            break;
+
+        case 'join':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                send_response(400, ['error' => 'Invalid request method']);
+            }
+            $input = json_decode(file_get_contents('php://input'), true);
+            $team_code = $input['team_join_code'] ?? '';
+            $player_name = trim($input['player_name'] ?? '');
+            $device_id = trim($input['device_id'] ?? '');
+            if (!preg_match('/^[A-Z0-9]{6}$/', $team_code) || $player_name === '' || $device_id === '') {
+                send_response(400, ['error' => 'Invalid input']);
+            }
+            $stmt = $pdo->prepare('SELECT t.id, t.name, t.role, t.game_id, t.join_code FROM teams t WHERE t.join_code = ?');
+            $stmt->execute([$team_code]);
+            $team = $stmt->fetch();
+            if (!$team) {
+                send_response(404, ['error' => 'Team not found']);
+            }
+            $stmt = $pdo->prepare('SELECT p.id FROM players p JOIN teams t ON p.team_id = t.id WHERE t.game_id = ? AND p.device_id = ?');
+            $stmt->execute([$team['game_id'], $device_id]);
+            if ($stmt->fetch()) {
+                send_response(409, ['error' => 'Device already joined a team']);
+            }
+            $stmt = $pdo->prepare('INSERT INTO players (team_id, device_id, display_name, is_captain) VALUES (?,?,?,0)');
+            $stmt->execute([$team['id'], $device_id, $player_name]);
+            $player_id = $pdo->lastInsertId();
+            send_response(200, [
+                'success' => true,
+                'team' => ['id' => $team['id'], 'name' => $team['name'], 'role' => $team['role'], 'join_code' => $team['join_code']],
+                'player' => ['id' => $player_id, 'name' => $player_name]
+            ]);
+            break;
+
+        default:
+            send_response(400, ['error' => 'Invalid action']);
+    }
+} catch (Exception $e) {
+    send_response(500, ['error' => 'Server error']);
+}
+?>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -52,3 +52,55 @@ button {
         height: 100vh;
     }
 }
+
+#team-screen {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+#teams-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.team-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem;
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    background: #fff;
+}
+
+.team-card.role-hunted {
+    border-left: 4px solid crimson;
+}
+
+.team-card.role-hunter {
+    border-left: 4px solid green;
+}
+
+#create-team {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+}
+
+#create-team input,
+#create-team select,
+#create-team button {
+    width: 100%;
+    margin-bottom: 0.5rem;
+}
+
+@media (min-width: 600px) {
+    #teams-list {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .team-card {
+        width: calc(50% - 0.5rem);
+    }
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,28 @@
         <a href="admin.html">Create New Game</a>
     </div>
 
+    <div id="team-screen" class="screen hidden">
+        <h1 id="game-title">Game Name</h1>
+        <h2>Choose Your Team</h2>
+
+        <div id="existing-teams">
+            <h3>Existing Teams</h3>
+            <div id="teams-list"></div>
+        </div>
+
+        <div id="create-team">
+            <h3>Create New Team</h3>
+            <input type="text" id="team-name" placeholder="Team Name" maxlength="50" />
+            <select id="team-role">
+                <option value="hunted">Hunted (Fleeing Team)</option>
+                <option value="hunter">Hunter (Chasing Team)</option>
+            </select>
+            <button id="create-team-btn">Create Team</button>
+        </div>
+
+        <button id="back-to-join">Back to Join</button>
+    </div>
+
     <div id="game-screen" class="screen hidden">
         <div id="map"></div>
     </div>
@@ -37,6 +59,140 @@
             onerror="console.error('❌ Failed to load Leaflet script', event)"></script>
     <script>
 console.log('🚀 Working inline script!');
+
+function getDeviceId() {
+    let id = localStorage.getItem('deviceId');
+    if (!id) {
+        id = crypto.randomUUID();
+        localStorage.setItem('deviceId', id);
+    }
+    return id;
+}
+
+function storeSession(gameData, teamData, playerData, code) {
+    localStorage.setItem('currentGame', JSON.stringify({ code, name: gameData.name }));
+    localStorage.setItem('currentTeam', JSON.stringify(teamData));
+    localStorage.setItem('currentPlayer', JSON.stringify(playerData));
+}
+
+function startGame() {
+    const teamScreen = document.getElementById('team-screen');
+    const gameScreen = document.getElementById('game-screen');
+    teamScreen.classList.add('hidden');
+    teamScreen.classList.remove('active');
+    gameScreen.classList.remove('hidden');
+    gameScreen.classList.add('active');
+}
+
+function showTeamSelection(gameData, code, playerName) {
+    const joinScreen = document.getElementById('join-screen');
+    const teamScreen = document.getElementById('team-screen');
+    const gameTitle = document.getElementById('game-title');
+    const teamsList = document.getElementById('teams-list');
+    const backBtn = document.getElementById('back-to-join');
+    const createBtn = document.getElementById('create-team-btn');
+    const teamName = document.getElementById('team-name');
+    const teamRole = document.getElementById('team-role');
+
+    joinScreen.classList.add('hidden');
+    joinScreen.classList.remove('active');
+    teamScreen.classList.remove('hidden');
+    teamScreen.classList.add('active');
+
+    gameTitle.textContent = gameData.name;
+    const deviceId = getDeviceId();
+
+    async function loadTeams() {
+        teamsList.innerHTML = '';
+        try {
+            const res = await fetch(`api/team.php?action=list&game_code=${code}`);
+            const data = await res.json();
+            if (res.ok) {
+                if (data.teams.length === 0) {
+                    teamsList.textContent = 'No teams yet.';
+                } else {
+                    data.teams.forEach(team => {
+                        const div = document.createElement('div');
+                        div.className = `team-card role-${team.role}`;
+                        div.innerHTML = `
+                            <span class="team-name">${team.name}</span>
+                            <span class="player-count">${team.player_count} players</span>
+                            <button data-code="${team.join_code}">Join</button>
+                        `;
+                        teamsList.appendChild(div);
+                    });
+                    teamsList.querySelectorAll('button').forEach(btn => {
+                        btn.onclick = async () => {
+                            const joinCode = btn.getAttribute('data-code');
+                            try {
+                                const joinRes = await fetch('api/team.php?action=join', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({
+                                        team_join_code: joinCode,
+                                        player_name: playerName,
+                                        device_id: deviceId
+                                    })
+                                });
+                                const joinData = await joinRes.json();
+                                if (joinRes.ok) {
+                                    storeSession(gameData, joinData.team, joinData.player, code);
+                                    startGame();
+                                } else {
+                                    alert(`Error: ${joinData.error}`);
+                                }
+                            } catch (e) {
+                                alert('Network error!');
+                            }
+                        };
+                    });
+                }
+            } else {
+                teamsList.textContent = 'Failed to load teams';
+            }
+        } catch (e) {
+            teamsList.textContent = 'Failed to load teams';
+        }
+    }
+
+    createBtn.onclick = async () => {
+        const tName = teamName.value.trim();
+        const role = teamRole.value;
+        if (!tName) return alert('Enter team name');
+        try {
+            const res = await fetch('api/team.php?action=create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    game_code: code,
+                    team_name: tName,
+                    role,
+                    player_name: playerName,
+                    device_id: deviceId
+                })
+            });
+            const data = await res.json();
+            if (res.ok) {
+                storeSession(gameData, data.team, data.player, code);
+                startGame();
+            } else {
+                alert(`Error: ${data.error}`);
+            }
+        } catch (e) {
+            alert('Network error!');
+        }
+    };
+
+    backBtn.onclick = () => {
+        teamScreen.classList.add('hidden');
+        teamScreen.classList.remove('active');
+        joinScreen.classList.remove('hidden');
+        joinScreen.classList.add('active');
+    };
+
+    loadTeams();
+}
+
 setTimeout(() => {
     const loading = document.getElementById('loading-screen');
     const join = document.getElementById('join-screen');
@@ -45,11 +201,11 @@ setTimeout(() => {
         join.classList.remove('hidden');
         join.classList.add('active');
         console.log('✅ Screen switched!');
-        
+
         const joinBtn = document.getElementById('join-btn');
         const joinCode = document.getElementById('join-code');
         const playerName = document.getElementById('player-name');
-        
+
         if (joinBtn && joinCode && playerName) {
             joinCode.oninput = (e) => e.target.value = e.target.value.toUpperCase();
             joinBtn.onclick = async () => {
@@ -59,7 +215,11 @@ setTimeout(() => {
                 try {
                     const res = await fetch(`api/game.php?action=get&code=${code}`);
                     const data = await res.json();
-                    alert(res.ok ? `Found: ${data.name}` : `Error: ${data.error}`);
+                    if (res.ok) {
+                        showTeamSelection(data, code, name);
+                    } else {
+                        alert(`Error: ${data.error}`);
+                    }
                 } catch(e) { alert('Network error!'); }
             };
             console.log('✅ Join setup complete!');


### PR DESCRIPTION
## Summary
- Add team selection screen and client logic for loading, creating, and joining teams
- Introduce `api/team.php` with endpoints to list, create, and join teams with validation
- Style team selection interface with responsive team cards and form

## Testing
- `php -l api/team.php`
- `php -l api/game.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8970297908323aa3de76508300f6a