### PR TITLE
Implement photo slot and upload system for hunted teams

### DIFF
--- a/api/photo.php
+++ b/api/photo.php
@@ -1,0 +1,89 @@
+<?php
+require_once __DIR__ . '/database.php';
+
+header('Content-Type: application/json');
+
+function send_response(int $status, array $data): void
+{
+    http_response_code($status);
+    echo json_encode($data);
+    exit;
+}
+
+$action = $_GET['action'] ?? '';
+$db = new Database();
+$pdo = $db->getConnection();
+$upload_dir = __DIR__ . '/../uploads/';
+
+try {
+    switch ($action) {
+        case 'upload':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                send_response(400, ['error' => 'Invalid request method']);
+            }
+            $slot_id = (int)($_POST['slot_id'] ?? 0);
+            $team_id = (int)($_POST['team_id'] ?? 0);
+            $player_id = (int)($_POST['player_id'] ?? 0);
+            $code = $_POST['slot_code_verification'] ?? '';
+            if (!$slot_id || !$player_id || !$team_id || $code === '' || !isset($_FILES['photo'])) {
+                send_response(400, ['error' => 'Missing parameters']);
+            }
+            $file = $_FILES['photo'];
+            if ($file['error'] !== UPLOAD_ERR_OK) {
+                send_response(400, ['error' => 'Upload error']);
+            }
+            if ($file['size'] > 5 * 1024 * 1024) {
+                send_response(400, ['error' => 'File too large']);
+            }
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            $mime = finfo_file($finfo, $file['tmp_name']);
+            finfo_close($finfo);
+            if (!in_array($mime, ['image/jpeg', 'image/png'])) {
+                send_response(400, ['error' => 'Invalid file format']);
+            }
+            $stmt = $pdo->prepare('SELECT slot_code, deadline FROM photo_slots WHERE id = ?');
+            $stmt->execute([$slot_id]);
+            $slot = $stmt->fetch();
+            if (!$slot) {
+                send_response(404, ['error' => 'Slot not found']);
+            }
+            if ($slot['slot_code'] !== $code) {
+                send_response(400, ['error' => 'Invalid slot code']);
+            }
+            if (strtotime($slot['deadline']) < time()) {
+                send_response(400, ['error' => 'Slot deadline passed']);
+            }
+            $ext = $mime === 'image/png' ? '.png' : '.jpg';
+            $filename = 'slot' . $slot_id . '_team' . $team_id . '_' . time() . $ext;
+            $target = $upload_dir . $filename;
+            if (!move_uploaded_file($file['tmp_name'], $target)) {
+                send_response(500, ['error' => 'Failed to save file']);
+            }
+            $stmt = $pdo->prepare('INSERT INTO photos (slot_id, player_id, file_path, original_filename, file_size, mime_type) VALUES (?, ?, ?, ?, ?, ?)');
+            $stmt->execute([$slot_id, $player_id, 'uploads/' . $filename, $file['name'], $file['size'], $mime]);
+            send_response(200, [
+                'success' => true,
+                'photo_url' => 'uploads/' . $filename,
+                'validation_status' => 'ok'
+            ]);
+            break;
+        case 'recent':
+            $game_id = (int)($_GET['game_id'] ?? 0);
+            if (!$game_id) {
+                send_response(400, ['error' => 'Missing game id']);
+            }
+            $stmt = $pdo->prepare('SELECT p.file_path, p.created_at, ps.slot_number, ps.slot_code, t.name AS team_name FROM photos p JOIN photo_slots ps ON p.slot_id = ps.id JOIN players pl ON p.player_id = pl.id JOIN teams t ON pl.team_id = t.id WHERE t.game_id = ? ORDER BY p.created_at DESC LIMIT 20');
+            $stmt->execute([$game_id]);
+            $photos = $stmt->fetchAll();
+            send_response(200, [
+                'success' => true,
+                'photos' => $photos
+            ]);
+            break;
+        default:
+            send_response(400, ['error' => 'Invalid action']);
+    }
+} catch (Exception $e) {
+    send_response(500, ['error' => 'Server error']);
+}
+?>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,6 +8,30 @@
     box-sizing: border-box;
 }
 
+.primary-action {
+    width: 100%;
+    padding: 1rem;
+    font-size: 1.1rem;
+    background: var(--role-color);
+    border: none;
+    color: white;
+    border-radius: 8px;
+}
+
+#slot-code-visual {
+    font-size: 2rem;
+    text-align: center;
+    padding: 1rem;
+    background: #f0f0f0;
+    border-radius: 8px;
+    margin: 0.5rem 0;
+}
+
+#upload-preview img {
+    max-width: 100%;
+    border-radius: 8px;
+}
+
 body {
     margin: 0;
     font-family: Arial, sans-serif;

--- a/index.html
+++ b/index.html
@@ -188,9 +188,110 @@ function startGame(teamData, playerData, gameData) {
     controls.innerHTML = '';
     if (teamData.role === 'hunted') {
         controls.innerHTML = `
-            <button id="upload-photo" class="primary-action">Upload Photo</button>
-            <div id="photo-slot">Next slot in: <span id="photo-slot-timer">--:--</span></div>
-            <div id="loc-status">Location: sharing</div>`;
+        <div id="hunted-controls">
+            <div id="photo-slot-info">
+                <h3>Photo Slot: <span id="current-slot-code">--</span></h3>
+                <div id="slot-timer">Upload required in: <span id="slot-countdown">--:--</span></div>
+            </div>
+            <div id="photo-upload-section">
+                <input type="file" id="photo-input" accept="image/*" capture="environment" style="display:none">
+                <button id="take-photo-btn" class="primary-action">📸 Upload Photo</button>
+                <div id="upload-preview"></div>
+                <div id="upload-status"></div>
+            </div>
+            <div id="slot-code-display">
+                <p>Include this code in your photo:</p>
+                <div id="slot-code-visual">--</div>
+            </div>
+        </div>`;
+
+        const joinInfo = JSON.parse(localStorage.getItem('currentGame'));
+        const slotCodeEl = document.getElementById('current-slot-code');
+        const slotVisual = document.getElementById('slot-code-visual');
+        const countdownEl = document.getElementById('slot-countdown');
+        let currentSlot = null;
+        let slotTimer = null;
+
+        async function refreshSlot() {
+            try {
+                const res = await fetch(`api/game.php?action=current_slot&code=${joinInfo.code}`);
+                const data = await res.json();
+                if (res.ok) {
+                    currentSlot = data;
+                    slotCodeEl.textContent = data.slot_code;
+                    slotVisual.textContent = data.slot_code;
+                    startCountdown(new Date(data.deadline).getTime());
+                }
+            } catch (e) { console.error(e); }
+        }
+
+        function startCountdown(endTime) {
+            if (slotTimer) clearInterval(slotTimer);
+            slotTimer = setInterval(() => {
+                const rem = Math.max(0, Math.floor((endTime - Date.now())/1000));
+                const m = Math.floor(rem / 60);
+                const s = rem % 60;
+                countdownEl.textContent = `${m}:${s.toString().padStart(2,'0')}`;
+                if (rem <= 0) clearInterval(slotTimer);
+            }, 1000);
+        }
+
+        const fileInput = document.getElementById('photo-input');
+        const takePhotoBtn = document.getElementById('take-photo-btn');
+        const preview = document.getElementById('upload-preview');
+        const statusEl = document.getElementById('upload-status');
+
+        takePhotoBtn.onclick = () => fileInput.click();
+        fileInput.onchange = async () => {
+            const file = fileInput.files[0];
+            if (!file || !currentSlot) return;
+            preview.innerHTML = '';
+            const img = document.createElement('img');
+            img.src = URL.createObjectURL(file);
+            preview.appendChild(img);
+
+            const fd = new FormData();
+            fd.append('slot_id', currentSlot.slot_id);
+            fd.append('team_id', teamData.id);
+            fd.append('player_id', playerData.id);
+            fd.append('slot_code_verification', currentSlot.slot_code);
+            fd.append('photo', file);
+            statusEl.textContent = 'Uploading...';
+            try {
+                const res = await fetch('api/photo.php?action=upload', { method: 'POST', body: fd });
+                const data = await res.json();
+                if (res.ok) {
+                    statusEl.textContent = 'Uploaded!';
+                    loadRecentPhotos();
+                    refreshSlot();
+                } else {
+                    statusEl.textContent = data.error || 'Upload failed';
+                }
+            } catch (e) {
+                statusEl.textContent = 'Network error';
+            }
+            fileInput.value = '';
+        };
+
+        async function loadRecentPhotos() {
+            try {
+                const res = await fetch(`api/photo.php?action=recent&game_id=${gameData.id}`);
+                const data = await res.json();
+                if (res.ok) {
+                    const container = document.getElementById('photos-container');
+                    container.innerHTML = '';
+                    data.photos.forEach(p => {
+                        const img = document.createElement('img');
+                        img.src = p.file_path;
+                        img.title = `${p.team_name} - ${p.slot_code}`;
+                        container.prepend(img);
+                    });
+                }
+            } catch (e) { console.error(e); }
+        }
+
+        refreshSlot();
+        loadRecentPhotos();
     } else {
         controls.innerHTML = `
             <button id="request-location" class="primary-action">Request Location</button>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -30,11 +30,11 @@ CREATE TABLE players (
 CREATE TABLE photo_slots (
     id INT AUTO_INCREMENT PRIMARY KEY,
     game_id INT NOT NULL,
-    team_id INT NOT NULL,
     slot_number INT NOT NULL,
+    slot_code VARCHAR(8) NOT NULL,
+    deadline DATETIME NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (game_id) REFERENCES games(id),
-    FOREIGN KEY (team_id) REFERENCES teams(id)
+    FOREIGN KEY (game_id) REFERENCES games(id)
 );
 
 CREATE TABLE photos (
@@ -42,6 +42,9 @@ CREATE TABLE photos (
     slot_id INT NOT NULL,
     player_id INT NOT NULL,
     file_path VARCHAR(255) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    file_size INT NOT NULL,
+    mime_type VARCHAR(50) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (slot_id) REFERENCES photo_slots(id),
     FOREIGN KEY (player_id) REFERENCES players(id)


### PR DESCRIPTION
## Summary
- add slot code generator and endpoints to manage photo slots
- create photo upload API with validation and recent photo feed
- add hunted UI with slot countdown and upload controls, plus styles and schema updates

## Testing
- `php -l api/game.php`
- `php -l api/photo.php`


------
https://chatgpt.com/codex/tasks/task_e_68a89c1a4bc483239fb480d1ddf57ea9