### PR TITLE
Simplify game start and UI for basic gameplay

### DIFF
--- a/api/game.php
+++ b/api/game.php
@@ -96,17 +96,7 @@ try {
             if (!preg_match('/^[A-Z0-9]{6}$/', $code)) {
                 send_response(400, ['error' => 'Invalid join code']);
             }
-            $input = json_decode(file_get_contents('php://input'), true);
-            $device_id = trim($input['device_id'] ?? '');
-            if ($device_id === '') {
-                send_response(400, ['error' => 'Invalid input']);
-            }
-            $stmt = $pdo->prepare('SELECT g.id FROM games g JOIN teams t ON g.id = t.game_id JOIN players p ON t.id = p.team_id WHERE g.join_code = ? AND p.device_id = ? AND p.is_captain = 1');
-            $stmt->execute([$code, $device_id]);
-            if (!$stmt->fetch()) {
-                send_response(403, ['error' => 'Not authorized']);
-            }
-            $stmt = $pdo->prepare('UPDATE games SET status = "active", started_at = NOW() WHERE join_code = ?');
+            $stmt = $pdo->prepare('UPDATE games SET status = "active" WHERE join_code = ?');
             $stmt->execute([$code]);
             if ($stmt->rowCount() === 0) {
                 send_response(404, ['error' => 'Game not found']);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,237 +1,45 @@
-/* Modern CSS Variables */
-:root {
-    --primary-blue: #2563eb;
-    --primary-red: #dc2626;
-    --success-green: #16a34a;
-    --warning-orange: #ea580c;
-
-    --bg-primary: #ffffff;
-    --bg-secondary: #f8fafc;
-    --bg-accent: #e2e8f0;
-
-    --text-primary: #1e293b;
-    --text-secondary: #64748b;
-    --text-light: #94a3b8;
-
-    --border-color: #e2e8f0;
-    --border-radius: 12px;
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-}
-
-/* Modern Base Styles */
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
+/* Just fix the ugly basics */
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
-    color: var(--text-primary);
-    line-height: 1.6;
-    min-height: 100vh;
+    font-family: system-ui, sans-serif;
+    background: #f5f5f5;
+    margin: 0;
+    padding: 20px;
 }
 
-/* Modern Card Design */
 .screen {
-    display: none;
-    min-height: 100vh;
-    padding: 1rem;
-    max-width: 500px;
+    max-width: 400px;
     margin: 0 auto;
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
 }
 
-.screen.active {
-    display: block;
-}
-
-/* Modern Button System */
-.btn-primary {
-    background: linear-gradient(135deg, var(--primary-blue) 0%, #1d4ed8 100%);
-    color: white;
+button {
+    width: 100%;
+    padding: 12px;
+    font-size: 16px;
     border: none;
-    padding: 0.875rem 1.5rem;
-    border-radius: var(--border-radius);
-    font-weight: 600;
-    font-size: 1rem;
+    border-radius: 6px;
     cursor: pointer;
-    transition: all 0.2s ease;
-    box-shadow: var(--shadow-sm);
-    width: 100%;
-    margin: 0.5rem 0;
+    margin: 8px 0;
 }
 
-.btn-primary:hover {
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
-    background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%);
-}
-
-.btn-secondary {
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    border: 2px solid var(--border-color);
-    padding: 0.875rem 1.5rem;
-    border-radius: var(--border-radius);
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    width: 100%;
-    margin: 0.5rem 0;
-}
-
-.btn-danger {
-    background: linear-gradient(135deg, var(--primary-red) 0%, #b91c1c 100%);
+.btn-primary {
+    background: #007bff;
     color: white;
 }
 
-/* Modern Input Design */
-input[type="text"], select {
+input, select {
     width: 100%;
-    padding: 0.875rem 1rem;
-    border: 2px solid var(--border-color);
-    border-radius: var(--border-radius);
-    font-size: 1rem;
-    transition: all 0.2s ease;
-    background: var(--bg-primary);
-    margin: 0.5rem 0;
+    padding: 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    margin: 8px 0;
+    font-size: 16px;
 }
 
-input[type="text"]:focus, select:focus {
-    outline: none;
-    border-color: var(--primary-blue);
-    box-shadow: 0 0 0 3px rgb(37 99 235 / 0.1);
-}
-
-/* Modern Team Cards */
-.team-card {
-    background: var(--bg-primary);
-    border-radius: var(--border-radius);
-    padding: 1.25rem;
-    margin: 0.75rem 0;
-    box-shadow: var(--shadow-sm);
-    border: 2px solid var(--border-color);
-    transition: all 0.2s ease;
-}
-
-.team-card:hover {
-    box-shadow: var(--shadow-md);
-    transform: translateY(-2px);
-}
-
-.team-card.role-hunted {
-    border-left: 6px solid var(--primary-red);
-}
-
-.team-card.role-hunter {
-    border-left: 6px solid var(--primary-blue);
-}
-
-/* Status Cards */
-.status-card {
-    background: var(--bg-primary);
-    border-radius: var(--border-radius);
-    padding: 1.5rem;
-    margin: 1rem 0;
-    box-shadow: var(--shadow-sm);
-    border: 1px solid var(--border-color);
-}
-
-/* Modern Typography */
-h1 {
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--text-primary);
-    margin-bottom: 0.5rem;
-    text-align: center;
-}
-
-h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 1.5rem 0 1rem 0;
-}
-
-h3 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 1rem 0 0.5rem 0;
-}
-
-.help-text {
-    color: var(--text-secondary);
-    font-size: 0.875rem;
-    margin-top: 0.5rem;
-}
-
-/* Role Badges */
-.role-badge {
-    display: inline-block;
-    padding: 0.375rem 0.75rem;
-    border-radius: 20px;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: white;
-}
-
-.role-badge.hunted {
-    background: var(--primary-red);
-}
-
-.role-badge.hunter {
-    background: var(--primary-blue);
-}
-
-/* Mobile Responsive */
-@media (max-width: 640px) {
-    .screen {
-        padding: 0.5rem;
-    }
-
-    h1 {
-        font-size: 1.75rem;
-    }
-}
-
-/* Utility Classes */
 .hidden {
     display: none;
-}
-
-#loading-screen {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.spinner {
-    width: 48px;
-    height: 48px;
-    border: 4px solid var(--bg-accent);
-    border-top-color: var(--primary-blue);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
-
-#map {
-    height: 400px;
-}
-
-#map-container.fullscreen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 1000;
 }
 

--- a/index.html
+++ b/index.html
@@ -28,10 +28,9 @@
         </div>
 
         <div id="game-control-section" class="hidden">
-            <div id="captain-controls" class="hidden">
-                <h3>Game Captain Controls</h3>
-                <button id="start-game-btn" class="btn-primary">🚀 Start Game</button>
-                <p class="help-text">Start the game when all teams are ready</p>
+            <div id="simple-start">
+                <button id="start-game-simple" class="btn-primary">🚀 Start Game</button>
+                <p>Anyone can start when teams are ready</p>
             </div>
 
             <div id="game-status">
@@ -371,21 +370,15 @@ function startGame(teamData, playerData, gameData) {
 
 function setupLobby(teamData, playerData, gameData, code) {
     const controlSection = document.getElementById('game-control-section');
-    const captainControls = document.getElementById('captain-controls');
     if (controlSection) controlSection.classList.remove('hidden');
-    if (playerData.is_captain && captainControls) {
-        captainControls.classList.remove('hidden');
-    }
 
-    const startBtn = document.getElementById('start-game-btn');
+    const startBtn = document.getElementById('start-game-simple');
     if (startBtn) {
         startBtn.onclick = async () => {
             showLoading();
             try {
                 await fetch(`api/game.php?action=start&code=${code}`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ device_id: getDeviceId() })
+                    method: 'POST'
                 });
             } catch (e) {
                 alert('Network error');
@@ -420,7 +413,7 @@ function setupLobby(teamData, playerData, gameData, code) {
                     teamDataRes.teams.forEach(t => {
                         const div = document.createElement('div');
                         div.className = `team-card role-${t.role}`;
-                        const players = t.players.map(p => `${p.display_name}${p.is_captain ? ' 👑' : ''}`).join(', ');
+                        const players = t.players.map(p => p.display_name).join(', ');
                         div.innerHTML = `<strong>${t.name}</strong><div>${players}</div>`;
                         summary.appendChild(div);
                     });
@@ -467,7 +460,7 @@ function showTeamSelection(gameData, code, playerName) {
                       data.teams.forEach(team => {
                           const div = document.createElement('div');
                           div.className = `team-card role-${team.role}`;
-                          const players = team.players.map(p => `${p.display_name}${p.is_captain ? ' 👑' : ''}`).join(', ');
+                          const players = team.players.map(p => p.display_name).join(', ');
                           div.innerHTML = `
                               <span class="team-name">${team.name}</span>
                               <span class="player-count">${team.player_count} players</span>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE games (
     join_code VARCHAR(8) NOT NULL UNIQUE,
     status ENUM('waiting','active','finished') NOT NULL DEFAULT 'waiting',
     photo_interval_seconds INT NOT NULL DEFAULT 120,
+    started_at TIMESTAMP NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- add `started_at` column to games schema
- remove captain-only start restrictions and just set game to active
- replace captain controls with simple "Start Game" button and trim CSS to basics

## Testing
- `php -l api/game.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8a87fe7fc83238a8edbf24b7a39b1