### PR TITLE
Improve demo game UX with auto-join and lobby fixes

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -401,3 +401,37 @@ input, select {
     }
 }
 
+/* Lobby Status Message */
+.lobby-status {
+    background: #fff3cd;
+    border: 1px solid #ffeaa7;
+    color: #856404;
+    padding: 1rem;
+    border-radius: 6px;
+    margin: 1rem 0;
+    text-align: center;
+    animation: fadeIn 0.3s ease;
+}
+
+.lobby-status strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+}
+
+.lobby-status small {
+    color: #6c5000;
+    font-size: 0.875rem;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+

--- a/fix_demo_status.php
+++ b/fix_demo_status.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/api/database.php';
+
+try {
+    $db = new Database();
+    $pdo = $db->getConnection();
+    
+    echo "🔧 Fixing Demo Game Status...\n";
+    
+    // Check current demo game status
+    $stmt = $pdo->prepare('SELECT * FROM games WHERE join_code = "DEMO01"');
+    $stmt->execute();
+    $demo = $stmt->fetch();
+    
+    if (!$demo) {
+        echo "❌ Demo game not found. Run setup_demo_game.php first.\n";
+        exit(1);
+    }
+    
+    echo "Current status: {$demo['status']}\n";
+    
+    // Force demo game to active status
+    $stmt = $pdo->prepare('UPDATE games SET status = "active", started_at = CURRENT_TIMESTAMP WHERE join_code = "DEMO01"');
+    $stmt->execute();
+    
+    echo "✅ Demo game set to ACTIVE status\n";
+    
+    // Check team and player counts
+    $stmt = $pdo->prepare('
+        SELECT 
+            COUNT(DISTINCT t.id) as team_count,
+            COUNT(DISTINCT p.id) as player_count,
+            COUNT(DISTINCT CASE WHEN p.device_id LIKE "bot_%" THEN p.id END) as bot_count
+        FROM teams t
+        LEFT JOIN players p ON t.id = p.team_id
+        WHERE t.game_id = ?
+    ');
+    $stmt->execute([$demo['id']]);
+    $stats = $stmt->fetch();
+    
+    echo "Game Stats:\n";
+    echo "- Teams: {$stats['team_count']}\n";
+    echo "- Players: {$stats['player_count']}\n";
+    echo "- Bots: {$stats['bot_count']}\n";
+    
+    // Update bot last_seen to make them appear online
+    $stmt = $pdo->prepare('
+        UPDATE players p 
+        JOIN teams t ON p.team_id = t.id 
+        SET p.last_seen = CURRENT_TIMESTAMP 
+        WHERE t.game_id = ? AND p.device_id LIKE "bot_%"
+    ');
+    $stmt->execute([$demo['id']]);
+    
+    echo "✅ Bot players marked as online\n";
+    
+    echo "\n🎮 Demo game is ready!\n";
+    echo "Join URL: index.html#DEMO01\n";
+    echo "Status: ACTIVE (should go directly to game screen)\n";
+    
+} catch (Exception $e) {
+    echo "❌ Error: " . $e->getMessage() . "\n";
+}
+?>

--- a/setup_demo_game.php
+++ b/setup_demo_game.php
@@ -20,7 +20,7 @@ try {
     }
     
     // Create demo game
-    $stmt = $pdo->prepare('INSERT INTO games (name, join_code, status, photo_interval_seconds) VALUES (?, ?, "active", 120)');
+    $stmt = $pdo->prepare('INSERT INTO games (name, join_code, status, photo_interval_seconds, started_at) VALUES (?, ?, "active", 120, CURRENT_TIMESTAMP)');
     $stmt->execute([$demo_name, $demo_code]);
     $game_id = $pdo->lastInsertId();
     


### PR DESCRIPTION
## Summary
- Auto-fill join codes from URL hashes and remember player names
- Directly start active games with lobby polling and status messages
- Provide demo game status reset script and ensure demo setup starts active

## Testing
- `php -l setup_demo_game.php`
- `php -l fix_demo_status.php`
- `node --check assets/js/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68a98605dbc48323a22d85e6047895a7