### PR TITLE
Fix cache busting logic for assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,12 +3,16 @@
     Header always set Cache-Control "no-cache, no-store, must-revalidate, max-age=0"
     Header always set Pragma "no-cache"
     Header always set Expires "Thu, 01 Jan 1970 00:00:00 GMT"
+    Header always set Last-Modified "Thu, 01 Jan 1970 00:00:00 GMT"
 </FilesMatch>
 
-# Short cache for CSS/JS with version control
+# Aggressive cache prevention for CSS/JS during development
 <FilesMatch "\.(css|js)$">
-    Header always set Cache-Control "public, max-age=300"
+    Header always set Cache-Control "no-cache, no-store, must-revalidate, max-age=0"
+    Header always set Pragma "no-cache"
+    Header always set Expires "Thu, 01 Jan 1970 00:00:00 GMT"
     Header always append Vary "Accept-Encoding"
+    Header always set Last-Modified "Thu, 01 Jan 1970 00:00:00 GMT"
 </FilesMatch>
 
 # API endpoints - no cache
@@ -18,3 +22,17 @@
     Header always set Access-Control-Allow-Methods "GET, POST, OPTIONS"
     Header always set Access-Control-Allow-Headers "Content-Type, Authorization"
 </FilesMatch>
+
+# Force reload for specific files
+<Files "game.js">
+    Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0"
+    Header set Pragma "no-cache"
+    Header set Expires "0"
+</Files>
+
+<Files "main.css">
+    Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0"
+    Header set Pragma "no-cache" 
+    Header set Expires "0"
+</Files>
+

--- a/admin.html
+++ b/admin.html
@@ -10,7 +10,15 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     
-    <link rel="stylesheet" href="assets/css/main.css?v=20250824_1110" />
+    <!-- Working Cache Buster for CSS -->
+    <script>
+(function() {
+    const timestamp = Date.now();
+    const buildVersion = '20250824_1110';
+
+    document.write(`<link rel="stylesheet" href="assets/css/main.css?v=${buildVersion}&t=${timestamp}" />`);
+})();
+    </script>
 </head>
 <body>
     <h1>Create Game</h1>
@@ -33,6 +41,16 @@
 
     <p><a href="index.html">Back to main game</a></p>
 
-    <script src="assets/js/admin.js?v=20250824_1110"></script>
+    <!-- Admin JS with Cache Busting -->
+    <script>
+(function() {
+    const timestamp = Date.now();
+    const buildVersion = '20250824_1110';
+
+    const script = document.createElement('script');
+    script.src = `assets/js/admin.js?v=${buildVersion}&t=${timestamp}`;
+    document.head.appendChild(script);
+})();
+    </script>
 </body>
 </html>

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1824,3 +1824,21 @@ if (document.readyState === 'loading') {
         console.log('🚫 Skipping immediate init, game already exists');
     }
 }
+
+// Cache busting verification and helpers
+console.log('🔍 Cache Busting Verification:', {
+    css_loaded: document.querySelector('link[href*="main.css"]')?.href,
+    js_loaded: document.currentScript?.src,
+    timestamp: new Date().toISOString(),
+    user_agent: navigator.userAgent.substring(0, 50)
+});
+
+// Global debug function
+window.debugCache = {
+    getCacheInfo: () => ({
+        css: document.querySelector('link[href*="main.css"]')?.href,
+        js_files: Array.from(document.scripts).map(s => s.src).filter(s => s),
+        loaded_at: new Date().toISOString()
+    }),
+    forceRefresh: () => window.location.reload(true)
+};

--- a/index.html
+++ b/index.html
@@ -10,39 +10,24 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     
-    <!-- CSS with Cache Busting -->
-    <link rel="stylesheet" href="assets/css/main.css?v=20250824_1110" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-
-    <!-- Emergency cache buster - remove after proper implementation -->
+    <!-- Working Cache Buster - Executes Immediately -->
     <script>
-// FIXED Emergency Cache Buster
+// WORKING Cache Buster - Runs BEFORE CSS processing
 (function() {
     const timestamp = Date.now();
-    console.log('🔄 Emergency cache busting:', timestamp);
-    
-    // ALWAYS update CSS URL - remove existing params and add new ones
-    document.addEventListener('DOMContentLoaded', () => {
-        const cssLink = document.querySelector('link[href*="main.css"]');
-        if (cssLink) {
-            const basePath = cssLink.href.split('?')[0]; // Remove existing params
-            cssLink.href = `${basePath}?v=${timestamp}&t=${Date.now()}`;
-            console.log('✅ CSS refreshed:', cssLink.href);
-        }
-        
-        const jsScript = document.querySelector('script[src*="game.js"]');
-        if (jsScript) {
-            const basePath = jsScript.src.split('?')[0]; // Remove existing params
-            const newScript = document.createElement('script');
-            newScript.src = `${basePath}?v=${timestamp}&t=${Date.now()}`;
-            newScript.onload = () => console.log('✅ JS refreshed:', newScript.src);
-            
-            jsScript.parentNode.insertBefore(newScript, jsScript);
-            jsScript.remove();
-        }
-    });
+    const buildVersion = '20250824_1110';
+
+    console.log('🔄 Cache busting active:', timestamp);
+
+    // Write CSS link with cache busting directly
+    document.write(`<link rel="stylesheet" href="assets/css/main.css?v=${buildVersion}&t=${timestamp}" />`);
+
+    console.log('✅ CSS loaded with cache busting');
 })();
-</script>
+    </script>
+
+    <!-- External CSS -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
 <body>
     <div id="loading-screen" class="screen active"><div class="spinner"></div></div>
@@ -128,6 +113,21 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="assets/js/game.js?v=20250824_1110"></script>
+
+    <!-- Game JS with Cache Busting -->
+    <script>
+// Load game.js with cache busting
+(function() {
+    const timestamp = Date.now();
+    const buildVersion = '20250824_1110';
+
+    const script = document.createElement('script');
+    script.src = `assets/js/game.js?v=${buildVersion}&t=${timestamp}`;
+    script.onload = () => console.log('✅ JS loaded with cache busting');
+    script.onerror = () => console.error('❌ JS failed to load');
+
+    document.head.appendChild(script);
+})();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace delayed emergency cache buster with immediate script in index.html
- Apply same cache busting approach to admin.html and load JS dynamically
- Add aggressive cache control rules to .htaccess and debug helpers in game.js

## Testing
- `node --check assets/js/game.js`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac47c895c0832394f6cfa8d5c34522